### PR TITLE
Add missing space to error message.

### DIFF
--- a/R/tween_state.R
+++ b/R/tween_state.R
@@ -154,7 +154,7 @@ tween_state <- function(.data, to, ease, nframes, id = NULL, enter = NULL, exit 
       } else if (all_na_to) {
         storage.mode(to[[i]]) <- storage.mode(from[[i]])
       } else {
-        stop('The ', names(to)[i], 'column differs in type between the two inputs', call. = FALSE)
+        stop('The ', names(to)[i], ' column differs in type between the two inputs', call. = FALSE)
       }
     }
   }


### PR DESCRIPTION
Fix run-on words.

`Error : The labelcolumn differs in type between the two inputs`
-> `Error : The label column differs in type between the two inputs`